### PR TITLE
[어드민] 뷰 엔드포인트 테스트 정의

### DIFF
--- a/src/main/java/org/example/projectboardadmin/controller/AdminUserAccountController.java
+++ b/src/main/java/org/example/projectboardadmin/controller/AdminUserAccountController.java
@@ -1,0 +1,23 @@
+package org.example.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/admin/members")
+@Controller
+public class AdminUserAccountController {
+
+    @GetMapping
+    public String members(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model
+    ) {
+        return "admin/members";
+    }
+
+}

--- a/src/main/java/org/example/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/org/example/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -1,0 +1,23 @@
+package org.example.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/article-comments")
+@Controller
+public class ArticleCommentManagementController {
+
+    @GetMapping
+    public String articleComments(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model
+    ) {
+        return "management/articleComments";
+    }
+
+}

--- a/src/main/java/org/example/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/org/example/projectboardadmin/controller/ArticleManagementController.java
@@ -1,0 +1,23 @@
+package org.example.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/articles")
+@Controller
+public class ArticleManagementController {
+
+    @GetMapping
+    public String articles(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model
+    ) {
+        return "management/articles";
+    }
+
+}

--- a/src/main/java/org/example/projectboardadmin/controller/MainController.java
+++ b/src/main/java/org/example/projectboardadmin/controller/MainController.java
@@ -1,0 +1,14 @@
+package org.example.projectboardadmin.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String root() {
+        return "forward:/management/articles";
+    }
+
+}

--- a/src/main/java/org/example/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/org/example/projectboardadmin/controller/UserAccountManagementController.java
@@ -1,0 +1,23 @@
+package org.example.projectboardadmin.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/management/user-accounts")
+@Controller
+public class UserAccountManagementController {
+
+    @GetMapping
+    public String userAccounts(
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model
+    ) {
+        return "management/userAccounts";
+    }
+
+}

--- a/src/main/resources/templates/admin/members.html
+++ b/src/main/resources/templates/admin/members.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/articleComments.html
+++ b/src/main/resources/templates/management/articleComments.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/articles.html
+++ b/src/main/resources/templates/management/articles.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/main/resources/templates/management/userAccounts.html
+++ b/src/main/resources/templates/management/userAccounts.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/test/java/org/example/projectboardadmin/controller/AdminUserAccountControllerTest.java
+++ b/src/test/java/org/example/projectboardadmin/controller/AdminUserAccountControllerTest.java
@@ -1,0 +1,38 @@
+package org.example.projectboardadmin.controller;
+
+import org.example.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 어드민 회원")
+@Import(SecurityConfig.class)
+@WebMvcTest(AdminUserAccountController.class)
+class AdminUserAccountControllerTest {
+
+    private final MockMvc mvc;
+
+    public AdminUserAccountControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 어드민 회원 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingAdminMembersView_thenReturnsAdminMembersView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/admin/members"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("admin/members"));
+    }
+
+}

--- a/src/test/java/org/example/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/org/example/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,0 +1,38 @@
+package org.example.projectboardadmin.controller;
+
+import org.example.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 댓글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleCommentManagementController.class)
+class ArticleCommentManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 댓글 관리 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingArticleCommentManagementView_thenReturnsArticleCommentManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/article-comments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/articleComments"));
+    }
+
+}

--- a/src/test/java/org/example/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/org/example/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,0 +1,37 @@
+package org.example.projectboardadmin.controller;
+
+import org.example.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 게시글 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(ArticleManagementController.class)
+class ArticleManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public ArticleManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 게시글 관리 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingArticleManagementView_thenReturnsArticleManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/articles"));
+    }
+}

--- a/src/test/java/org/example/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/org/example/projectboardadmin/controller/MainControllerTest.java
@@ -1,0 +1,37 @@
+package org.example.projectboardadmin.controller;
+
+import org.example.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 루트 컨트롤러")
+@Import(SecurityConfig.class)
+@WebMvcTest(MainController.class)
+class MainControllerTest {
+
+    private final MockMvc mvc;
+
+    public MainControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 루트 페이지 -> 게시글 관리 페이지 Forwarding")
+    @Test
+    void givenNothing_whenRequestingRootView_thenForwardsToArticleManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/management/articles"))
+                .andExpect(forwardedUrl("/management/articles"));
+    }
+
+}

--- a/src/test/java/org/example/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/org/example/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,0 +1,38 @@
+package org.example.projectboardadmin.controller;
+
+import org.example.projectboardadmin.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 회원 관리")
+@Import(SecurityConfig.class)
+@WebMvcTest(UserAccountManagementController.class)
+class UserAccountManagementControllerTest {
+
+    private final MockMvc mvc;
+
+    public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[view][GET] 회원 관리 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingUserAccountManagementView_thenReturnsUserAccountManagementView() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/management/user-accounts"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("management/userAccounts"));
+    }
+
+}


### PR DESCRIPTION
뷰 엔드포인트 5개를 위한 컨트롤러와 테스트, 기초 뷰 파일 추가.

어드민 서비스에 필요한 5가지 뷰 엔드포인트에 대한 컨트롤러와 기본 테스트를 추가.  
각 컨트롤러는 최소한의 핸들러 메소드를 포함하고 있으며, 뷰 템플릿 파일은 기본적인 HTML 구조만 가지고 있다.

구체적인 구현이나 콘텐츠는 포함되지 않았으므로, 이후 개발 과정에서 디테일한 내용을 추가해야 한다.

This closes #7 